### PR TITLE
Fixed array declarations for stats-options.php to support PHP version < 5.4

### DIFF
--- a/stats-options.php
+++ b/stats-options.php
@@ -8,8 +8,8 @@ if( ! empty( $_POST['Submit'] ) ) {
     check_admin_referer( 'wp-stats_options' );
     $stats_url = ! empty( $_POST['stats_url'] ) ? esc_url_raw( $_POST['stats_url'] ) : '';
     $stats_mostlimit = ! empty( $_POST['stats_mostlimit'] ) ? intval( trim( $_POST['stats_mostlimit'] ) ) : 10;
-    $stats_display =  empty( $_POST['stats_display'] ) ? $_POST['stats_display'] : [];
-    $stats_display_array = [];
+    $stats_display =  empty( $_POST['stats_display'] ) ? $_POST['stats_display'] : array();
+    $stats_display_array = array();
     if( ! empty( $stats_display ) ) {
         foreach($stats_display as $stat_display) {
             $stat_display = addslashes( $stat_display );


### PR DESCRIPTION
The official [PHP documentation](http://php.net/manual/en/language.types.array.php) states that as of PHP 5.4 you can also use the short array syntax, which replaces `array()` with `[]` to declare arrays. However, when the running PHP version is less than 5.4.0, stats-options.php throws the following error (when invoked through the WordPress control panel settings section): 

> Parse error: syntax error, unexpected '[' in [...]/wp-content/plugins/wp-stats/stats-options.php

Array declarations for the script changed from using square brackets (`$someArray = [];`) to the `$someArray = array();` approach which is supported by older versions of PHP as well (tested with PHP 5.3.xx and WordPress 4.5.3).
